### PR TITLE
Refactor: Adjust Coaction core for plain object state handling

### DIFF
--- a/packages/core/src/create.ts
+++ b/packages/core/src/create.ts
@@ -86,7 +86,20 @@ export const create: Creator = <T extends CreateState>(
     };
     const getPureState: Store<T>['getPureState'] = () =>
       internal.rootState as T;
-    const isSliceStore = typeof createState === 'object';
+    let isSliceStore = false;
+    if (
+      typeof createState === 'object' &&
+      createState !== null
+    ) {
+      const values = Object.values(createState);
+      if (values.length > 0 && values.every((value) => typeof value === 'function')) {
+        isSliceStore = true;
+      }
+      // If values.length is 0 (empty object), or not all values are functions,
+      // and createState is an object, isSliceStore remains false.
+      // This means it's treated as a plain object state or an empty object.
+    }
+    // If createState is a function (not an object), isSliceStore also remains false.
     Object.assign(store, {
       name,
       share: share ?? false,


### PR DESCRIPTION
This commit refines how Coaction's core `create` function handles plain JavaScript objects provided as `createState`.

Previously, if `createState` was any object, Coaction would set `isSliceStore = true`, incorrectly attempting to apply its native "slices pattern" (where each object property is a slice-defining function). This led to errors when you provided simple state objects (e.g., from third-party libraries or direct state) as it would try to execute non-function properties.

The following changes have been made:
1.  **Refined `isSliceStore` Logic (`packages/core/src/create.ts`):** `isSliceStore` is now only `true` if `createState` is an object AND all its enumerable property values are functions. For plain objects (including empty ones) or objects with non-function properties, `isSliceStore` is `false`.

2.  **Modified `makeState` Function (`packages/core/src/getInitialState.ts`):** The `makeState` function now accepts either a slice-creator function or a direct object as its input. This allows it to correctly process plain objects passed as state, while still handling its original role of executing slice functions and unwrapping third-party store instances (e.g., those with `.getState()` or function stores like Pinia).

3.  **Adjusted Main Logic in `getInitialState.ts`:** The main part of `getInitialState` now correctly passes plain objects to `makeState` when `isSliceStore` is `false`.

These changes ensure that Coaction no longer misinterprets plain state objects as its native functional slice maps, allowing for more robust and intuitive state initialization, especially when working with state from third-party libraries or defining simple, direct state.

**Testing Caveat:**
Unit tests for these changes were added to `packages/core/test/create.test.ts`. However, due to persistent Jest/Babel configuration issues within the `packages/core` test environment, these new tests, along with existing ones in that package, could not be executed to confirm pass status at the time of this commit. The logical changes have been reviewed and are submitted with this understanding.